### PR TITLE
Fix DatabasePropertySchema structure by wrapping with additional level

### DIFF
--- a/core/src/main/kotlin/notion/api/v1/model/databases/DatabasePropertySchema.kt
+++ b/core/src/main/kotlin/notion/api/v1/model/databases/DatabasePropertySchema.kt
@@ -26,7 +26,9 @@ constructor(val select: List<SelectOptionSchema>? = null) : DatabasePropertySche
 
 open class MultiSelectPropertySchema
 @JvmOverloads
-constructor(val multiSelect: List<SelectOptionSchema>? = null) : DatabasePropertySchema
+constructor(multiSelect: List<SelectOptionSchema>? = null) : DatabasePropertySchema {
+  val multiSelect = mapOf("options" to multiSelect)
+}
 
 class DatePropertySchema @JvmOverloads constructor(val date: Map<String, Any> = emptyMap()) :
     DatabasePropertySchema


### PR DESCRIPTION
Based on the document, we need to wrap the SelectOptionSchema list with an additional level named "options".
https://developers.notion.com/reference/property-schema-object

This change is tested, but I am not familiar with maven project, so I tested the change by moving the source code to my Android gradle project and ran the build in IDEA, and it seems fine.
<img width="638" alt="image" src="https://user-images.githubusercontent.com/375642/183036240-195333a5-8dd1-4342-aafc-d8c83b3c2837.png">


This will solve bug https://github.com/seratch/notion-sdk-jvm/issues/67