### PR TITLE
Add id to SelectOptionSchema

### DIFF
--- a/core/src/main/kotlin/notion/api/v1/model/databases/DatabasePropertySchema.kt
+++ b/core/src/main/kotlin/notion/api/v1/model/databases/DatabasePropertySchema.kt
@@ -18,7 +18,7 @@ open class NumberPropertySchema @JvmOverloads constructor(val number: Number = N
 
 open class SelectOptionSchema
 @JvmOverloads
-constructor(val name: String, val color: OptionColor? = null)
+constructor(val name: String, val color: OptionColor? = null, val id: String? = null)
 
 open class SelectPropertySchema
 @JvmOverloads


### PR DESCRIPTION
This is required to edit the options (add or remove an option) on a SelectPropertySchema or a MultiSelectPropertySchema.
