### PR TITLE
Fix #81 Add StatusFilter to PropertyFilter

### DIFF
--- a/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/PropertyFilter.kt
+++ b/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/PropertyFilter.kt
@@ -24,4 +24,5 @@ constructor(
     var file: FilesFilter? = null,
     var relation: RelationFilter? = null,
     var formula: FormulaFilter? = null,
+    var status: StatusFilter? = null,
 ) : QueryTopLevelFilter, CompoundFilterElement

--- a/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/condition/StatusFilter.kt
+++ b/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/condition/StatusFilter.kt
@@ -1,0 +1,10 @@
+package notion.api.v1.model.databases.query.filter.condition
+
+open class StatusFilter
+@JvmOverloads
+constructor(
+    var equals: String? = null,
+    var doesNotEqual: String? = null,
+    var isEmpty: Boolean? = null,
+    var isNotEmpty: Boolean? = null,
+)


### PR DESCRIPTION
This pull request may be a solution for #81 

While using this SDK for my project, I noticed that PropertyFilter does not have a filter for the status property and I found the same issue in #81 

At that time, the issue can't be resolved but now it can be. So I added StatusFilter based on [Notion API reference](https://developers.notion.com/reference/post-database-query-filter#status).

> This PR is my first contribution and it’s first Kotlin experience from Java. Please let me know if you find something wrong with my PR. I’ll fix.