### PR TITLE
Update actions, add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,22 +10,24 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    name: Java ${{ matrix.java-version }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:
       matrix:
-        java-version: [ '11', '14' ]
+        java-version: [ '11', '17' ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
       - name: Check the code format
         run: |
           mvn spotless:check
       - name: Compile the main/test code
         run: |
-          mvn test-compile --no-transfer-progress -DfailIfNoTests=false '-Dtest=tests.**.*Test' test
+          mvn --no-transfer-progress -DfailIfNoTests=false '-Dtest=tests.**.*Test' test


### PR DESCRIPTION
This:
* Update all the actions to the latest available version
* Uses the latest version of Ubuntu instead of pinning version 20.04
* Replaces Java version 14 with 17 (latest LTS)
* Selects `temurin` as the Java distribution to be used by `setup-java` (mandatory parameter in the latest version)
* Adds the Dependabot configuration for the Maven and GitHub Actions ecosystem
* Removes the `test-compile` explicit invocation as it's anyway [triggered](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle) by `test`