### PR TITLE
Allow job executions on branches

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,11 +2,7 @@
 
 name: CI Build
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
With the current configuration, jobs run only in two cases:
* When something is pushed to `main`
* After the creation of a PR against `main`

This means they don't run on branches, from the repo or from forks, before a PR is created.

With this, jobs run with any combination, including with PRs against non-`main` branches (although it's probably not a common use case for this repo).