### PR TITLE
PropertyFilter: add rollup option

### DIFF
--- a/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/PropertyFilter.kt
+++ b/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/PropertyFilter.kt
@@ -25,4 +25,5 @@ constructor(
     var relation: RelationFilter? = null,
     var formula: FormulaFilter? = null,
     var status: StatusFilter? = null,
+    var rollup: RollupFilter? = null,
 ) : QueryTopLevelFilter, CompoundFilterElement

--- a/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/condition/RollupFilter.kt
+++ b/core/src/main/kotlin/notion/api/v1/model/databases/query/filter/condition/RollupFilter.kt
@@ -1,0 +1,34 @@
+package notion.api.v1.model.databases.query.filter.condition
+
+open class RollupFilter
+@JvmOverloads
+constructor(
+    var any: Content? = null,
+    var every: Content? = null,
+    var none: Content? = null,
+) {
+  open class Content
+  @JvmOverloads
+  constructor(
+      var title: TextFilter? = null,
+      var richText: TextFilter? = null,
+      var url: TextFilter? = null,
+      var email: TextFilter? = null,
+      var phoneNumber: TextFilter? = null,
+      var number: NumberFilter? = null,
+      var checkbox: CheckboxFilter? = null,
+      var select: SelectFilter? = null,
+      var multiSelect: MultiSelectFilter? = null,
+      var date: DateFilter? = null,
+      var timestamp: String? = null, // "created_time", "last_edited_time"
+      var createdTime: TimestampFilter? = null,
+      var lastEditedTime: TimestampFilter? = null,
+      var createdBy: PeopleFilter? = null,
+      var lastEditedBy: PeopleFilter? = null,
+      var file: FilesFilter? = null,
+      var relation: RelationFilter? = null,
+      var formula: FormulaFilter? = null,
+      var status: StatusFilter? = null,
+      var rollup: RollupFilter? = null,
+  )
+}


### PR DESCRIPTION
Rollup property search spec can be found at: https://developers.notion.com/reference/post-database-query-filter#rollup

In short:

* Rollup properties have content of any other kind.
* Filters consume the same properties like all the other filters (except for the "property" field, which is already specified)

So a new `RollupFilter` class was created with an inner class `RollupFilter.Content` for the content spec.
That calss was registered as `rollup` in `PropertyFilter`.