### PR TITLE
fix: #186 Fix `Mention` for pages - use `PageReference` instead of `Page` to make the call to Notion API work.

### DIFF
--- a/core/src/main/kotlin/notion/api/v1/model/pages/PageProperty.kt
+++ b/core/src/main/kotlin/notion/api/v1/model/pages/PageProperty.kt
@@ -72,7 +72,7 @@ constructor(
     constructor(
         var type: RichTextMentionType? = null,
         var user: User? = null,
-        val page: Page? = null,
+        val page: PageReference? = null,
         val database: Database? = null,
         val date: Date? = null,
     )


### PR DESCRIPTION
fix: #186 Fix `Mention` for pages - use `PageReference` (that contains page id only) instead of complete `Page` object.
- See https://developers.notion.com/reference/rich-text#page-mention-type-object